### PR TITLE
Enable notebook syntax highlighting

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -11,6 +11,7 @@ dependencies:
     - pandoc
     - pygments
     - jupyter_client
+    - ipython
 
       # Depends
     - qcportal


### PR DESCRIPTION
The symptom is that local builds correctly have syntax highlighting
in the output builds, but on RTD, they are lacking.

Based on research from readthedocs/readthedocs.org#5688 the problem
comes from the multiple warnings of:

> WARNING: Pygments lexer name 'ipython3' is not known

We do see this in our RTD builds as well: https://readthedocs.org/api/v2/build/9139203.txt

Based on that issue and spatialaudio/nbsphinx#24, The fix to this issue is to add
`ipython` to the requirements.txt explicitly. So, this PR tries that.

cc @dgasmith 